### PR TITLE
Fix namespace of createShared function

### DIFF
--- a/docs/docs/modules/oatpp-mbedtls/README.md
+++ b/docs/docs/modules/oatpp-mbedtls/README.md
@@ -51,7 +51,7 @@ auto config = oatpp::mbedtls::Config::createDefaultServerConfigShared(serverCert
 
 /* Create Transport Stream Provider */
 /* Replace With Your Custom Transport Stream Provider */
-auto transportStreamProvider = oatpp::network::server::tcp::ConnectionProvider::createShared({"localhost", 443, oatpp::network::Address::IP_4});
+auto transportStreamProvider = oatpp::network::tcp::server::ConnectionProvider::createShared({"localhost", 443, oatpp::network::Address::IP_4});
 
 /* Create Secure Connection Provider */
 auto connectionProvider = oatpp::mbedtls::server::ConnectionProvider::createShared(config, transportStreamProvider);

--- a/docs/docs/simple-vs-async/README.md
+++ b/docs/docs/simple-vs-async/README.md
@@ -44,7 +44,7 @@ public:
    *  Create ConnectionProvider component which listens on the port
    */
   OATPP_CREATE_COMPONENT(std::shared_ptr<oatpp::network::ServerConnectionProvider>, serverConnectionProvider)([] {
-    return oatpp::network::server::tcp::ConnectionProvider::createShared({"localhost", 8000, oatpp::network::Address::IP_4});
+    return oatpp::network::tcp::server::ConnectionProvider::createShared({"localhost", 8000, oatpp::network::Address::IP_4});
   }());
 
   /**
@@ -91,7 +91,7 @@ public:
    *  Create ConnectionProvider component which listens on the port
    */
   OATPP_CREATE_COMPONENT(std::shared_ptr<oatpp::network::ServerConnectionProvider>, serverConnectionProvider)([] {
-    return oatpp::network::server::tcp::ConnectionProvider::createShared({"localhost", 8000, oatpp::network::Address::IP_4});
+    return oatpp::network::tcp::server::ConnectionProvider::createShared({"localhost", 8000, oatpp::network::Address::IP_4});
   }());
 
   /**

--- a/docs/docs/start/step-by-step/README.md
+++ b/docs/docs/start/step-by-step/README.md
@@ -32,7 +32,7 @@ void run() {
   auto connectionHandler = oatpp::web::server::HttpConnectionHandler::createShared(router);
 
   /* Create TCP connection provider */
-  auto connectionProvider = oatpp::network::server::tcp::ConnectionProvider::createShared({"localhost", 8000, oatpp::network::Address::IP_4});
+  auto connectionProvider = oatpp::network::tcp::server::ConnectionProvider::createShared({"localhost", 8000, oatpp::network::Address::IP_4});
 
   /* Create server which takes provided TCP connections and passes them to HTTP connection handler */
   oatpp::network::Server server(connectionProvider, connectionHandler);
@@ -112,7 +112,7 @@ void run() {
   auto connectionHandler = oatpp::web::server::HttpConnectionHandler::createShared(router);
 
   /* Create TCP connection provider */
-  auto connectionProvider = oatpp::network::server::tcp::ConnectionProvider::createShared({"localhost", 8000, oatpp::network::Address::IP_4});
+  auto connectionProvider = oatpp::network::tcp::server::ConnectionProvider::createShared({"localhost", 8000, oatpp::network::Address::IP_4});
 
   /* Create server which takes provided TCP connections and passes them to HTTP connection handler */
   oatpp::network::Server server(connectionProvider, connectionHandler);
@@ -228,7 +228,7 @@ void run() {
   auto connectionHandler = oatpp::web::server::HttpConnectionHandler::createShared(router);
 
   /* Create TCP connection provider */
-  auto connectionProvider = oatpp::network::server::tcp::ConnectionProvider::createShared({"localhost", 8000, oatpp::network::Address::IP_4});
+  auto connectionProvider = oatpp::network::tcp::server::ConnectionProvider::createShared({"localhost", 8000, oatpp::network::Address::IP_4});
 
   /* Create server which takes provided TCP connections and passes them to HTTP connection handler */
   oatpp::network::Server server(connectionProvider, connectionHandler);
@@ -332,7 +332,7 @@ public:
    *  Create ConnectionProvider component which listens on the port
    */
   OATPP_CREATE_COMPONENT(std::shared_ptr<oatpp::network::ServerConnectionProvider>, serverConnectionProvider)([] {
-    return oatpp::network::server::tcp::ConnectionProvider::createShared({"localhost", 8000, oatpp::network::Address::IP_4});
+    return oatpp::network::tcp::server::ConnectionProvider::createShared({"localhost", 8000, oatpp::network::Address::IP_4});
   }());
 
   /**


### PR DESCRIPTION
I think that the examples contained an error.
The function `createShared` was in the examples in namespace `oatpp::network::server::tcp::ConnectionProvider`, but in the [sample repo](https://github.com/oatpp/oatpp-starter/blob/f1925c52c2e6a153b6cbcb5df626ea0d7c29e88b/src/AppComponent.hpp#L23) it is in namespace `oatpp::network::tcp::server::ConnectionProvider`.

I used both versions and only the version in the example repo worked. So I corrected the examples.