### PR TITLE
website changes for Visual Studio 2022 windows build

### DIFF
--- a/docs/docs/installation/windows/README.md
+++ b/docs/docs/installation/windows/README.md
@@ -8,11 +8,12 @@ sidebarDepth: 0
 
 ## Requirements 
 
-- Microsoft Visual Studio (Tested with Visual Studio 2017)
+- Microsoft Visual Studio (Tested with Visual Studio 2022)
 - CMake (Latest version recommended)
 - Git
 
 ## Install Oat++
+Build at an administrator command prompt.
 
 ```bash
 $ git clone https://github.com/oatpp/oatpp.git
@@ -22,6 +23,7 @@ $ cd build\
 
 $ cmake ..
 $ cmake --build . --target INSTALL
+$ copy src\Debug\oatpp.pdb  "C:\Program Files (x86)\oatpp\lib\oatpp-1.3.0"
 ```
 
 ### Installation CMake options:
@@ -34,3 +36,19 @@ $ cmake --build . --target INSTALL
 |`OATPP_DISABLE_ENV_OBJECT_COUNTERS`|`OFF`|If `ON`, do not count oatpp objects (do not detect memory-leaks). This will increase performance. <br> **Note:** DO NOT use this flags to build/run application tests, as tests won't detect memory-leaks.|
 |`OATPP_DISABLE_POOL_ALLOCATIONS`|`OFF`|If `ON`, do not use oatpp memory-pools.|
 |`OATPP_COMPAT_BUILD_NO_THREAD_LOCAL`|`OFF`|Build without `thread_local` feature. See [#81](https://github.com/oatpp/oatpp/issues/81).|
+
+## Application build notes
+
+To build Oat++ applications under Windows do the following:
+
+- Define an environment variable OATPP_HOME as `C:\Program Files (x86)\oatpp`
+- Add this code to the main program after all the `#includes`:
+```cpp
+#if defined(WIN32) || defined(_WIN32)
+#pragma comment(lib, "Ws2_32.lib")
+#endif 
+```
+- Make the following changes to Visual Studio projects:
+  - add an additional include directory `$(OATPP_HOME)\include\oatpp-1.3.0\oatpp`
+  - add an additional lib directory `%OATPP_HOME%\lib\oatpp-1.3.0`
+  - add an additional link dependency `oatpp.lib`

--- a/docs/docs/start/step-by-step/README.md
+++ b/docs/docs/start/step-by-step/README.md
@@ -23,6 +23,10 @@ To get basic components overview let's take a look at the simplest oatpp server 
 #include "oatpp/network/Server.hpp"
 #include "oatpp/network/tcp/server/ConnectionProvider.hpp"
 
+#if defined(WIN32) || defined(_WIN32)
+#pragma comment(lib, "Ws2_32.lib")
+#endif
+
 void run() {
 
   /* Create Router for HTTP requests routing */
@@ -84,6 +88,10 @@ requests to it via `Router`:
 
 #include "oatpp/network/Server.hpp"
 #include "oatpp/network/tcp/server/ConnectionProvider.hpp"
+
+#if defined(WIN32) || defined(_WIN32)
+#pragma comment(lib, "Ws2_32.lib")
+#endif
 
 /** 
  * Custom Request Handler
@@ -166,6 +174,10 @@ will be serialized to JSON.
 #include "oatpp/network/tcp/server/ConnectionProvider.hpp"
 
 #include "oatpp/core/macro/codegen.hpp"
+
+#if defined(WIN32) || defined(_WIN32)
+#pragma comment(lib, "Ws2_32.lib")
+#endif
 
 /* Begin DTO code-generation */
 #include OATPP_CODEGEN_BEGIN(DTO)
@@ -372,6 +384,10 @@ Now all major components are initialized in one place which makes it easy to con
 #include "oatpp/network/Server.hpp"
 
 #include "oatpp/core/macro/codegen.hpp"
+
+#if defined(WIN32) || defined(_WIN32)
+#pragma comment(lib, "Ws2_32.lib")
+#endif
 
 /* Begin DTO code-generation */
 #include OATPP_CODEGEN_BEGIN(DTO)
@@ -823,6 +839,10 @@ In folder `test/` create file `Tests.cpp`:
 #include "MyControllerTest.hpp"
 
 #include <iostream>
+
+#if defined(WIN32) || defined(_WIN32)
+#pragma comment(lib, "Ws2_32.lib")
+#endif
 
 void runTests() {
 


### PR DESCRIPTION
These are notes on the changes to the README.md's.

==================================================
File: docs/docs/installation/windows/README.md
--------------------------------------------------
Change: updated Visual Studio version

 ## Requirements 
 
-- Microsoft Visual Studio (Tested with Visual Studio 2022)
+- Microsoft Visual Studio (Tested with Visual Studio 2017)
 
--------------------------------------------------
Change: Windows build cmake must be run on an administrator command prompt 

 ## Install Oat++
-Build at an administrator command prompt.
 
--------------------------------------------------
Change: added additional Windows install step to copy pdb file. This should be possible to add to cmake/module-install.cmake, I haven't figured it out yet. We can wait until then if you'd like.

 ```bash
 $ git clone https://github.com/oatpp/oatpp.git
  
 $ cmake ..
 $ cmake --build . --target INSTALL
-$ copy src\Debug\oatpp.pdb  "C:\Program Files (x86)\oatpp\lib\oatpp-1.3.0"
 ```
 
--------------------------------------------------
Change: changes required to the Visual Studio solution after creating:

  define environment variable OATPP_HOME as "C:\Program Files (x86)\oatpp"
  add additional include dir: $(OATPP_HOME)\include\oatpp-1.3.0\oatpp
  add additional lib dir: %OATPP_HOME%\lib\oatpp-1.3.0 [won't get into why "$()" for include and "%..%" for libs]
  add additional link dependency: oatpp.lib

-## Application build notes
-
-To build Oat++ applications under Windows do the following:
-
-- Define an environment variable OATPP_HOME as `C:\Program Files (x86)\oatpp`
-- Add this code to the main program after all the `#includes`:
-```cpp
-#if defined(WIN32) || defined(_WIN32)
-#pragma comment(lib, "Ws2_32.lib")
-#endif 
-```
-- Make the following changes to Visual Studio projects:
-  - add an additional include directory `$(OATPP_HOME)\include\oatpp-1.3.0\oatpp`
-  - add an additional lib directory `%OATPP_HOME%\lib\oatpp-1.3.0`
-  - add an additional link dependency `oatpp.lib`

==================================================
File: docs/docs/start/step-by-step/README.md
--------------------------------------------------
Change: required after the #includes in main programs examples

 #include ...
 #include ...
 
-#if defined(WIN32) || defined(_WIN32)
-#pragma comment(lib, "Ws2_32.lib")
-#endif

...
