### PR TITLE
#27 revert some windows build website changes

### DIFF
--- a/docs/docs/installation/windows/README.md
+++ b/docs/docs/installation/windows/README.md
@@ -23,7 +23,6 @@ $ cd build\
 
 $ cmake ..
 $ cmake --build . --target INSTALL
-$ copy src\Debug\oatpp.pdb  "C:\Program Files (x86)\oatpp\lib\oatpp-1.3.0"
 ```
 
 ### Installation CMake options:
@@ -39,16 +38,12 @@ $ copy src\Debug\oatpp.pdb  "C:\Program Files (x86)\oatpp\lib\oatpp-1.3.0"
 
 ## Application build notes
 
-To build Oat++ applications under Windows do the following:
+To build Oat++ applications under Windows do the following.
 
-- Define an environment variable OATPP_HOME as `C:\Program Files (x86)\oatpp`
 - Add this code to the main program after all the `#includes`:
 ```cpp
 #if defined(WIN32) || defined(_WIN32)
 #pragma comment(lib, "Ws2_32.lib")
 #endif 
 ```
-- Make the following changes to Visual Studio projects:
-  - add an additional include directory `$(OATPP_HOME)\include\oatpp-1.3.0\oatpp`
-  - add an additional lib directory `%OATPP_HOME%\lib\oatpp-1.3.0`
-  - add an additional link dependency `oatpp.lib`
+


### PR DESCRIPTION
Removed recommendations to manually edit generated Visual Studio 
Removed instruction to manually install .pdb file

The latter was found to be necessary to build with Visual Studio 2022 as was adding this to main programs. This should be checked on earlier/other versions.

This was also found to be necessary with Visual Studio 2022, these changes were kept in. This also should be checked, it may be desired to remove these too.

#if defined(WIN32) || defined(_WIN32)
#pragma comment(lib, "Ws2_32.lib")
#endif 