### PR TITLE
Update README.md

### DIFF
--- a/docs/docs/installation/unix-linux/README.md
+++ b/docs/docs/installation/unix-linux/README.md
@@ -43,7 +43,6 @@ $ make install
 |`OATPP_BUILD_TESTS`|`ON`|Set it to `OFF` to disable tests build.|
 |`OATPP_LINK_ATOMIC`|`OFF`|Explicitly link `libatomic`. This flag is ignored for: MSVC, MINGW, APPLE, FreeBSD.|
 |`OATPP_DISABLE_ENV_OBJECT_COUNTERS`|`OFF`|If `ON`, do not count oatpp objects (do not detect memory-leaks). This will increase performance. <br> **Note:** DO NOT use this flags to build/run application tests, as tests won't detect memory-leaks.|
-|`OATPP_DISABLE_POOL_ALLOCATIONS`|`OFF`|If `ON`, do not use oatpp memory-pools.|
 |`OATPP_COMPAT_BUILD_NO_THREAD_LOCAL`|`OFF`|Build without `thread_local` feature. See [#81](https://github.com/oatpp/oatpp/issues/81).|
 
 ## Installing Prerequisites


### PR DESCRIPTION
Removed OATPP_DISABLE_POOL_ALLOCATIONS because it's deprecated and has no effect.