### PR TITLE
 Fix links in docs/docs/installation/vcpkg/README.md

### DIFF
--- a/docs/docs/installation/vcpkg/README.md
+++ b/docs/docs/installation/vcpkg/README.md
@@ -8,8 +8,8 @@ sidebarDepth: 0
 
 The community maintained ports are available for the majority of oatpp modules.  
 
-- [Vcpkg Website](https://docs.microsoft.com/en-us/cpp/build/vcpkg) - learn more about vcpkg.
-- [Available Ports](https://vcpkg.info/) - Search for 'oatpp'.
+- [Vcpkg Website](https://learn.microsoft.com/en-us/vcpkg/get_started/overview) - learn more about vcpkg.
+- [Available Ports](https://vcpkg.io/) - Search for 'oatpp'.
 
 ## Credits
 


### PR DESCRIPTION
Fixed links

Previous link to Vcpkg through Microsoft redirected to https://vcpkg.io/en/. New link goes to Microsoft's overview.

Previous link for Available Ports linked to a typosquatting domain to download a browser extension. New link correctly goes to https://vcpkg.io/.